### PR TITLE
zeit: add time comparison methods

### DIFF
--- a/src/zeit.zig
+++ b/src/zeit.zig
@@ -826,11 +826,11 @@ pub const Time = struct {
         const time_instant = time.instant();
 
         if (self_instant.timestamp > time_instant.timestamp) {
-            return TimeComparison.after;
+            return .after;
         } else if (self_instant.timestamp < time_instant.timestamp) {
-            return TimeComparison.before;
+            return .before;
         } else {
-            return TimeComparison.equal;
+            return .equal;
         }
     }
 
@@ -846,7 +846,7 @@ pub const Time = struct {
         return self_instant.timestamp < time_instant.timestamp;
     }
 
-    pub fn equal(self: Time, time: Time) bool {
+    pub fn eql(self: Time, time: Time) bool {
         const self_instant = self.instant();
         const time_instant = time.instant();
         return self_instant.timestamp == time_instant.timestamp;

--- a/src/zeit.zig
+++ b/src/zeit.zig
@@ -421,6 +421,12 @@ pub const Date = struct {
     day: u5, // 1-31
 };
 
+pub const TimeComparison = enum(u2) {
+    after,
+    before,
+    equal,
+};
+
 pub const Time = struct {
     year: i32 = 1970,
     month: Month = .jan,
@@ -813,6 +819,37 @@ pub const Time = struct {
                 }
             },
         }
+    }
+
+    pub fn compare(self: Time, time: Time) TimeComparison {
+        const self_instant = self.instant();
+        const time_instant = time.instant();
+
+        if (self_instant.timestamp > time_instant.timestamp) {
+            return TimeComparison.after;
+        } else if (self_instant.timestamp < time_instant.timestamp) {
+            return TimeComparison.before;
+        } else {
+            return TimeComparison.equal;
+        }
+    }
+
+    pub fn after(self: Time, time: Time) bool {
+        const self_instant = self.instant();
+        const time_instant = time.instant();
+        return self_instant.timestamp > time_instant.timestamp;
+    }
+
+    pub fn before(self: Time, time: Time) bool {
+        const self_instant = self.instant();
+        const time_instant = time.instant();
+        return self_instant.timestamp < time_instant.timestamp;
+    }
+
+    pub fn equal(self: Time, time: Time) bool {
+        const self_instant = self.instant();
+        const time_instant = time.instant();
+        return self_instant.timestamp == time_instant.timestamp;
     }
 };
 


### PR DESCRIPTION
Boolean time comparison methods (after, before, equal) similar to those in go's time package. Additional compare method that returns an enum with after, before and equal values