### PR TITLE
Add `bufStrftime()` convenience function

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ pub fn main() void {
     // Or...golang magic date specifiers. Format strings are not required to be comptime
     try dt.gofmt(anywriter, "2006-01-02 15:04:05 MST");
 
+    // Format using strftime straight to buffer.
+    var buf: [128]u8 = undefined;
+    const formatted_date_string = try dt.bufStrftime(buf, "%Y-%m-%d %H:%M:%S %Z");
+
     // Load an arbitrary location using IANA location syntax. The location name
     // comes from an enum which will automatically map IANA location names to
     // Windows names, as needed. Pass an optional EnvMap to support TZDIR


### PR DESCRIPTION
## Description

Being new to Zig I found the `anywriter` interface confusing, and it took me a while to figure out.
After figuring it out I found the boilerplate with setting up a writer distracting, so I figured something that can write straight to a buffer, similar to `std.fmt.bufPrint` would be nice to have?

The changes didn't take long so I wouldn't mind doing the same thing for `gofmt()` if you like the idea of this.

Also happy to make any changes if you think this has some merit but needs work ☺️ 

**Changes:**

* Add `bufStrftime()` function as a wrapper around `strftime()`.
* Same unit tests run for `strftime()` and `bufStrftime()`.
* Added an example to the readme.

