### PR TITLE
fix(windows): use correct conditionals for dst end month

### DIFF
--- a/src/timezone.zig
+++ b/src/timezone.zig
@@ -900,11 +900,11 @@ pub const Windows = struct {
             }
             if (time.wDay == days) {
                 if (time.wHour == end.wHour) {
-                    return time.wMinute >= end.wMinute;
+                    return time.wMinute < end.wMinute;
                 }
-                return time.wHour >= end.wHour;
+                return time.wHour < end.wHour;
             }
-            return time.wDay >= days;
+            return time.wDay < days;
         }
         return false;
     }


### PR DESCRIPTION
When we are in the end month, we are in DST if we are *less* than the
end time.

Fixes: #11
