### PR TITLE
zeit: prevent integer overflow when creating Instant from unix_timestamp

### DIFF
--- a/src/zeit.zig
+++ b/src/zeit.zig
@@ -258,7 +258,7 @@ pub const Instant = struct {
 pub fn instant(cfg: Instant.Config) !Instant {
     const ts: Nanoseconds = switch (cfg.source) {
         .now => std.time.nanoTimestamp(),
-        .unix_timestamp => |unix| unix * ns_per_s,
+        .unix_timestamp => |unix| @as(i128, unix) * ns_per_s,
         .unix_nano => |nano| nano,
         .time => |time| time.instant().timestamp,
         .iso8601,


### PR DESCRIPTION
Explicitly cast unix_timestamp to i128 to prevent integer overflow. Zig
will overflow because unix_timestamp is i64, but Nanoseconds is i128
which wouldn't overflow in some cases.

Fixes: #18
