### PR TITLE
Support for RFC1123 HTTP dates

### DIFF
--- a/src/zeit.zig
+++ b/src/zeit.zig
@@ -177,6 +177,9 @@ pub const Instant = struct {
 
         /// Parse a datetime from an RFC2822 date-time spec. This is an alias for RFC5322
         rfc2822: []const u8,
+
+        /// Parse a datetime from an RFC1123 date-time spec
+        rfc1123: []const u8,
     };
 
     /// convert this Instant to another timezone
@@ -276,6 +279,10 @@ pub fn instant(cfg: Instant.Config) !Instant {
         .rfc5322,
         => |eml| blk: {
             const t = try Time.fromRFC5322(eml);
+            break :blk t.instant().timestamp;
+        },
+        .rfc1123 => |http_date| blk: {
+            const t = try Time.fromRFC1123(http_date);
             break :blk t.instant().timestamp;
         },
     };


### PR DESCRIPTION
As specified in RFC2616: https://www.rfc-editor.org/rfc/rfc2616#section-3.3

I haven't included parsers for RFC850 and ANSI dates as they are obsolete, but I could add support for these if desired. 

Fixes #28 