### PR TITLE
Fix parsing of ISO 8601 basic format

### DIFF
--- a/src/zeit.zig
+++ b/src/zeit.zig
@@ -638,7 +638,7 @@ pub const Time = struct {
                         4 => { // MMDD
                             const m: u4 = try parseInt(u4, iso[i .. i + 2], 10);
                             time.month = @enumFromInt(m);
-                            time.day = try parseInt(u4, iso[i + 2 .. token_end], 10);
+                            time.day = try parseInt(u5, iso[i + 2 .. token_end], 10);
                             state = .hour;
                         },
                         else => return error.InvalidISO8601,

--- a/src/zeit.zig
+++ b/src/zeit.zig
@@ -794,6 +794,26 @@ pub const Time = struct {
             const offset = try Time.fromISO8601("20000212T111213+1230");
             try std.testing.expectEqual(12 * s_per_hour + 30 * s_per_min, offset.offset);
         }
+        {
+            const basic = try Time.fromISO8601("20240224T154944");
+            try std.testing.expectEqual(2024, basic.year);
+            try std.testing.expectEqual(Month.feb, basic.month);
+            try std.testing.expectEqual(24, basic.day);
+            try std.testing.expectEqual(15, basic.hour);
+            try std.testing.expectEqual(49, basic.minute);
+            try std.testing.expectEqual(44, basic.second);
+            try std.testing.expectEqual(0, basic.offset);
+        }
+        {
+            const basic = try Time.fromISO8601("20240224T154944Z");
+            try std.testing.expectEqual(2024, basic.year);
+            try std.testing.expectEqual(Month.feb, basic.month);
+            try std.testing.expectEqual(24, basic.day);
+            try std.testing.expectEqual(15, basic.hour);
+            try std.testing.expectEqual(49, basic.minute);
+            try std.testing.expectEqual(44, basic.second);
+            try std.testing.expectEqual(0, basic.offset);
+        }
     }
 
     pub fn fromRFC5322(eml: []const u8) !Time {


### PR DESCRIPTION
The issue was caused by a typo. `time.day` is a `u5`, not a `u4`. 

Fixes #33 