### PR TITLE
Fix missed i64 to i32 cast in isDST

### DIFF
--- a/src/timezone.zig
+++ b/src/timezone.zig
@@ -859,7 +859,7 @@ pub const Windows = struct {
         // In the months between
         if (time.wMonth > start.wMonth and time.wMonth < end.wMonth) return true;
 
-        const days_from_epoch = @divFloor(timestamp, s_per_day);
+        const days_from_epoch: zeit.Days = @intCast(@divFloor(timestamp, s_per_day));
         // first_of_month is the weekday on the first of the month
         const first_of_month = zeit.weekdayFromDays(days_from_epoch - time.wDay + 1);
 


### PR DESCRIPTION
Commit 3fee42ce172673ae83dab4f10efaf97a97ed557b missed a i64 > i32 cast resulting in an error that rendered the package unusable.