### PR TITLE
Bump package version to 0.10.0-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,21 @@
 
 A time library written in zig.
 
-## Install 
+## Install
+
+zeit's `main` branch currently tracks Zig 0.17-dev.
+
 ```
 zig fetch --save git+https://github.com/rockorager/zeit?ref=main
 ```
 
-Or install a [tag](https://github.com/rockorager/zeit/tags) instead of main.
+For the last Zig 0.16-compatible release, fetch `v0.9.0`:
+
+```
+zig fetch --save git+https://github.com/rockorager/zeit?ref=v0.9.0
+```
+
+Or install another [tag](https://github.com/rockorager/zeit/tags) instead of main.
 
 ## Usage
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .zeit,
     .fingerprint = 0x888df3e4939b8ee4,
-    .version = "0.9.0",
+    .version = "0.10.0-dev",
     .dependencies = .{},
     .paths = .{
         "LICENSE",


### PR DESCRIPTION
## Summary
- bump package version to `0.10.0-dev`
- document that `main` now tracks Zig 0.17-dev
- document `v0.9.0` as the last Zig 0.16-compatible release

## Testing
- `zig build test`