### PR TITLE
Fix head reference in zig fetch commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ A time library written in zig.
 zeit's `main` branch currently tracks Zig 0.17-dev.
 
 ```
-zig fetch --save git+https://github.com/rockorager/zeit?ref=main
+zig fetch --save git+https://github.com/rockorager/zeit#main
 ```
 
 For the last Zig 0.16-compatible release, fetch `v0.9.0`:
 
 ```
-zig fetch --save git+https://github.com/rockorager/zeit?ref=v0.9.0
+zig fetch --save git+https://github.com/rockorager/zeit#v0.9.0
 ```
 
 Or install another [tag](https://github.com/rockorager/zeit/tags) instead of main.


### PR DESCRIPTION
This syntax:

    URL?ref=REF

is what ends up in the build.zig.zon, but does *not* work when used on the command line.  What works on command line is:

    URL#REF

E.g. following test:

    $ grep 'rock\|zeit-' build.zig.zon
    $ zig fetch --save git+https://github.com/rockorager/zeit?ref=main
    info: resolved to commit 905396257dcf0b1bfa3c0e8265657a0e748105ad
    $ grep 'rock\|zeit-' build.zig.zon
                .url = "git+https://github.com/rockorager/zeit?ref=main#905396257dcf0b1bfa3c0e8265657a0e748105ad",
                .hash = "zeit-0.10.0-dev-5I6bk3m9AgB8Ndev81pibV70MJe9VCOXAGZBNU833c4Y",
    $ zig fetch --save git+https://github.com/rockorager/zeit?ref=v0.9.0
    info: resolved to commit 905396257dcf0b1bfa3c0e8265657a0e748105ad
    warning: overwriting existing dependency named 'zeit'
    $ grep 'rock\|zeit-' build.zig.zon
                .url = "git+https://github.com/rockorager/zeit?ref=v0.9.0#905396257dcf0b1bfa3c0e8265657a0e748105ad",
                .hash = "zeit-0.10.0-dev-5I6bk3m9AgB8Ndev81pibV70MJe9VCOXAGZBNU833c4Y",
    $ zig fetch --save git+https://github.com/rockorager/zeit#v0.9.0
    info: resolved ref 'v0.9.0' to commit b1c1c2fcbc71fd7799a316bbcf0ff88d06d80ccc
    warning: overwriting existing dependency named 'zeit'
    $ grep 'rock\|zeit-' build.zig.zon
                .url = "git+https://github.com/rockorager/zeit?ref=v0.9.0#b1c1c2fcbc71fd7799a316bbcf0ff88d06d80ccc",
                .hash = "zeit-0.9.0-5I6bk2m9AgBSMH8-L6rYJkwuQAyhXplnfxnvTSGzVHUR",
    $

shows that:

  1. on empty build.zig.zon, using `?ref=main` fetches main

  2. then `?ref=v0.9.0` *still* fetches main, it just updates URL but leaves commit reference and package hash untouched

  3. correct form `#v0.9.0` will update URL, commit reference and package hash.