### PR TITLE
Several TZ related fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pub fn main() !void {
     const dt = now_local.time();
 
     // Print it out
-    std.debug.print("{}", .{dt});
+    std.debug.print("{}\n", .{dt});
 
     // zeit.Time{
     //    .year = 2024,

--- a/README.md
+++ b/README.md
@@ -26,18 +26,14 @@ Or install another [tag](https://github.com/rockorager/zeit/tags) instead of mai
 const std = @import("std");
 const zeit = @import("zeit");
 
-pub fn main() !void {
-    const allocator = std.heap.page_allocator;
-    var threaded = std.Io.Threaded.init(allocator, .{});
-    defer threaded.deinit();
-    const io = threaded.io();
+pub fn main(init: std.process.Init) !void {
 
     // Get a "now" instant in UTC.
-    const now = zeit.instant(.{.now = io}, &zeit.utc);
+    const now = zeit.instant(.{ .now = init.io }, &zeit.utc);
 
     // Load our local timezone. This needs an allocator. Optionally pass in a
     // zeit.EnvConfig to support TZ and TZDIR environment variables
-    const local = try zeit.local(allocator, io, .{});
+    const local = try zeit.local(init.gpa, init.io, .{});
     defer local.deinit();
 
     // Convert our instant to a new timezone
@@ -78,7 +74,7 @@ pub fn main() !void {
     // Load an arbitrary location using IANA location syntax. The location name
     // comes from an enum which will automatically map IANA location names to
     // Windows names, as needed. Pass an optional EnvConfig to support TZDIR
-    const vienna = try zeit.loadTimeZone(allocator, io, .@"Europe/Vienna", .{});
+    const vienna = try zeit.loadTimeZone(init.gpa, init.io, .@"Europe/Vienna", .{});
     defer vienna.deinit();
 
     // Parse an Instant from an ISO8601 or RFC3339 string

--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ pub fn main() !void {
         .iso8601,
         "2024-03-16T08:38:29.496-1200",
         &zeit.utc,
-    });
+    );
 
     _ = try zeit.instantFromText(
         .rfc3339,
         "2024-03-16T08:38:29.496706064-1200",
         &zeit.utc,
-    });
+    );
 }
 ```

--- a/src/timezone.zig
+++ b/src/timezone.zig
@@ -175,10 +175,10 @@ pub const Posix = struct {
                             state = .std_offset;
                         },
                         else => {
-                            i = std.mem.indexOfAnyPos(u8, str, i, "+-0123456789") orelse return error.InvalidPosix;
-                            std_ = str[0..i];
-                            // backup one so this gets parsed as an offset
-                            i -= 1;
+                            const std_len = std.mem.indexOfNone(u8, str, std.ascii.letters) orelse return error.InvalidPosix;
+                            if (std_len < 3) return error.InvalidPosix; // we don't check TZNAME_MAX
+                            std_ = str[0..std_len];
+                            i = std_len - 1;
                             state = .std_offset;
                         },
                     }

--- a/src/zeit.zig
+++ b/src/zeit.zig
@@ -43,6 +43,9 @@ pub fn local(alloc: std.mem.Allocator, io: std.Io, env: EnvConfig) !TimeZone {
         },
         else => {
             if (env.tz) |tz| {
+                // Following glibc convention, which uses UTC if the TZ envvar
+                // is set, but the value is empty string.
+                if (tz.len == 0) return utc; // 'utc' being .fixed, utc.deinit() is a no-op
                 return localFromEnv(alloc, io, tz, env);
             }
 


### PR DESCRIPTION
Details are in commit messages; feel free to cherry-pick and/or request changes (or squash as needed).

 *  2 minor fixes in README
 *  using juicy main in README example
 *  fixing crash  when `TZ="0"`, ie. numeric (should return error)
 *  fixing crash when `TZ=""`, ie. returning UTC instead (like glibc)

The last one is the most interesting: the empty string case is not clearly specified, so @rockorager , should zeit follow what glibc does?   If not, I'd be happy to change it to some other behavior.